### PR TITLE
Improve date parsing robustness in Query.date

### DIFF
--- a/src/python/paperai/query.py
+++ b/src/python/paperai/query.py
@@ -6,6 +6,7 @@ import datetime
 import re
 import sys
 
+from dateutil import parser
 from rich.console import Console
 
 from txtai.pipeline import Tokenizer
@@ -176,13 +177,16 @@ class Query:
         """
 
         if date:
-            date = datetime.datetime.strptime(date, "%Y-%m-%d %H:%M:%S")
+            try:
+                parsed = parser.parse(date)
+            except (ValueError, TypeError):
+                return date
 
             # 1/1 dates had no month/day specified, use only year
-            if date.month == 1 and date.day == 1:
-                return date.strftime("%Y")
+            if parsed.month == 1 and parsed.day == 1:
+                return parsed.strftime("%Y")
 
-            return date.strftime("%Y-%m-%d")
+            return parsed.strftime("%Y-%m-%d")
 
         return None
 

--- a/test/python/testquery.py
+++ b/test/python/testquery.py
@@ -25,6 +25,16 @@ class TestQuery(unittest.TestCase):
         self.assertEqual(Query.authors(None), None)
         self.assertEqual(Query.date(None), None)
 
+    def testDateFormats(self):
+        """
+        Test multiple date string formats.
+        """
+
+        self.assertEqual(Query.date("2024-01-01 00:00:00"), "2024")
+        self.assertEqual(Query.date("2024-05-02"), "2024-05-02")
+        self.assertEqual(Query.date("2024-05-02T13:45:21Z"), "2024-05-02")
+        self.assertEqual(Query.date("not-a-date"), "not-a-date")
+
     def testRun(self):
         """
         Test query execution


### PR DESCRIPTION
Accept ISO-8601 and date-only formats via dateutil parser while preserving existing year-only output for 1/1 publication dates. Add focused unit coverage for mixed date formats and invalid values.